### PR TITLE
修复安卓部分机型discard失效的问题

### DIFF
--- a/physics-3d/assets/common/effects/bonus-unlit.effect
+++ b/physics-3d/assets/common/effects/bonus-unlit.effect
@@ -3,7 +3,7 @@ CCEffect %{
   - name: opaque
     passes:
     - vert: bonus-unlit-vs:vert
-      frag: bonus-unlit-fs:frag
+      frag: bonus-unlit-fs
       properties: &props
         color:        { value: [1, 1, 1, 1], editor: { type: color } }
         tilingOffset: { value: [1, 1, 0, 0] }
@@ -12,7 +12,7 @@ CCEffect %{
   - name: transparent
     passes:
     - vert: bonus-unlit-vs:vert
-      frag: bonus-unlit-fs:frag
+      frag: bonus-unlit-fs
       depthStencilState:
         depthTest: true
         depthWrite: false
@@ -94,9 +94,10 @@ CCProgram bonus-unlit-fs %{
     vec4 clipColor;
   };
 
-  
+  layout(location = 0) out vec4 fragColorX;
 
-  vec4 frag () {
+  void main()
+  {
     vec4 o = vec4(1, 1, 1, 1);
 
     #if USE_TEXTURE
@@ -106,15 +107,16 @@ CCProgram bonus-unlit-fs %{
     if(abs(o.r - clipColor.r) <= clipColor.a && abs(o.g - clipColor.g) <= clipColor.a && abs(o.b - clipColor.b) <= clipColor.a) {
       discard;
     }
-    
-    #if USE_COLOR
-      o *= color;
-    #endif
+    else
+    {
+      #if USE_COLOR
+        o *= color;
+      #endif
 
-    #if USE_VERTEX_COLOR
-      o *= v_color;
-    #endif
-
-    return CCFragOutput(o);
+      #if USE_VERTEX_COLOR
+        o *= v_color;
+      #endif
+      fragColorX = o;
+    }
   }
 }%


### PR DESCRIPTION
驱动BUG，为规避这个BUG，调用discard之后不要再给fragColor赋值。

出现这个问题的机型有： 红米k20p、oppo r11t、小米6。

@YunHsiao @minggo

相关issue: https://github.com/cocos-creator/3d-tasks/issues/7959  https://github.com/cocos-creator/3d-tasks/issues/6189